### PR TITLE
Don't require backports.unittest_mock for recent Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ setup_params = dict(
 	] + pytest_runner + sphinx + wheel,
 	tests_require=[
 		'pytest>=2.8',
-		'backports.unittest_mock',
-	],
+	] + ['backports.unittest_mock'] if sys.version_info < (3, 3) else [],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",
 		"Intended Audience :: Developers",


### PR DESCRIPTION
I didn't see a prettier way to do this but you might have one, feel free to reject the PR if you do :)
